### PR TITLE
Add cable retraction control and slider synchronization

### DIFF
--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -253,6 +253,17 @@ function formatMotorLabel(id) {
   return `${id.charAt(0).toUpperCase()}${id.slice(1)}`;
 }
 
+function toggleButtonPulse(button, active) {
+  if (!button) return;
+  const shouldPulse = Boolean(active);
+  button.classList.toggle('is-pulsing', shouldPulse);
+  if (shouldPulse) {
+    button.setAttribute('aria-busy', 'true');
+  } else {
+    button.removeAttribute('aria-busy');
+  }
+}
+
 
 function renderMotorEngagement(motor) {
   if (!motor) return;
@@ -351,11 +362,6 @@ function toggleMotorCableSet(motor) {
     disarmMotorCableSet(motor);
     return;
   }
-  motors.forEach((other) => {
-    if (other !== motor) {
-      disarmMotorCableSet(other, { silent: true });
-    }
-  });
   motor.setArmed = true;
   toggleButtonPulse(motor.setCableButton, true);
   if (elements.message) {

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -719,6 +719,13 @@ motors.forEach((motor) => {
   motor.simSlider.addEventListener('input', () => {
     const sliderDistance = Number(motor.simSlider.value);
     const normalized = Math.max(0, Math.min(1, sliderDistance / MAX_TRAVEL_INCHES));
+    const previous = motor.normalized;
+    const previousDistance = previous * MAX_TRAVEL_INCHES;
+    if (sliderDistance > previousDistance + SIM_SLIDER_STEP / 2) {
+      motor.direction = 1;
+    } else if (sliderDistance < previousDistance - SIM_SLIDER_STEP / 2) {
+      motor.direction = -1;
+    }
     motor.normalized = normalized;
     motor.trail.push(normalized);
     if (motor.trail.length > TRAIL_LENGTH) {

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -168,7 +168,7 @@ function createMotor(id, refs) {
     retractionTarget: DEFAULT_RETRACTION_BOTTOM,
     retractionSpeed: RETRACTION_SPEED_IPS,
     normalized,
-    direction: 0,
+    direction: 1,
     trail: new Array(TRAIL_LENGTH).fill(normalized),
     lastTravel: travelInches,
     phase: 'idle',
@@ -1234,7 +1234,11 @@ function update(timestamp) {
     motor.normalized = normalized;
     const travel = motor.normalized * MAX_TRAVEL_INCHES;
     const derivative = delta > 0 ? (normalized - previous) / delta : 0;
-    motor.direction = derivative >= 0 ? 1 : -1;
+    if (derivative > 0) {
+      motor.direction = 1;
+    } else if (derivative < 0) {
+      motor.direction = -1;
+    }
 
     const engageDistance = motor.engagementDistance;
     const engageThresholdDistance = Math.min(

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -15,7 +15,7 @@ const SIM_SLIDER_STEP = 0.1;
 const DEFAULT_RETRACTION_BOTTOM = 1;
 const WEIGHT_ENGAGE_OFFSET = 1;
 const FORCE_PROFILE_LOCK_MESSAGE =
-  'Retract the cables to or below their engagement distance to adjust the force profiles.';
+  'Retract both cables to or below their engagement distance to adjust these';
 
 const elements = {
   workoutState: document.getElementById('workoutState'),
@@ -67,6 +67,8 @@ function motorBeyondEngagement(motor) {
   return travel > motor.engagementDistance + MOVEMENT_EPSILON;
 }
 
+let forceProfileLockHintVisible = false;
+
 function updateForceProfileLockState() {
   const locked = motors.some((motor) => motorBeyondEngagement(motor));
 
@@ -75,7 +77,10 @@ function updateForceProfileLockState() {
   }
 
   if (elements.forceLockHint) {
-    elements.forceLockHint.hidden = !locked;
+    if (!locked) {
+      forceProfileLockHintVisible = false;
+    }
+    elements.forceLockHint.hidden = !(locked && forceProfileLockHintVisible);
   }
 
   const controls = [
@@ -94,6 +99,12 @@ function updateForceProfileLockState() {
   });
 
   return locked;
+}
+
+function notifyForceProfileLock() {
+  forceProfileLockHintVisible = true;
+  updateForceProfileLockState();
+  setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
 }
 
 function getForceCurveCopy(mode, intensityPercent) {
@@ -614,7 +625,7 @@ elements.startToggle.addEventListener('click', toggleWorkout);
 elements.forceSelect.addEventListener('change', (event) => {
   if (updateForceProfileLockState()) {
     event.target.value = lastForceCurveMode;
-    setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
+    notifyForceProfileLock();
     return;
   }
 
@@ -630,7 +641,7 @@ if (elements.forceCurveIntensity) {
   const handleForceIntensityInput = (event) => {
     if (updateForceProfileLockState()) {
       event.target.value = String(forceCurveIntensity);
-      setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
+      notifyForceProfileLock();
       return;
     }
     setForceCurveIntensity(event.target.value);
@@ -643,7 +654,7 @@ if (elements.eccentricToggle) {
   elements.eccentricToggle.addEventListener('click', (event) => {
     if (updateForceProfileLockState()) {
       event.preventDefault();
-      setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
+      notifyForceProfileLock();
       return;
     }
 
@@ -675,7 +686,7 @@ if (elements.eccentricSelect) {
   elements.eccentricSelect.addEventListener('change', (event) => {
     if (updateForceProfileLockState()) {
       event.target.value = lastEccentricMode;
-      setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
+      notifyForceProfileLock();
       return;
     }
 

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -14,9 +14,6 @@ const RETRACTION_SPEED_IPS =
 const SIM_SLIDER_STEP = 0.1;
 const DEFAULT_RETRACTION_BOTTOM = 1;
 const WEIGHT_ENGAGE_OFFSET = 1;
-const FORCE_PROFILE_LOCK_MESSAGE =
-  'Retract both cables to or below their engagement distance to adjust these';
-
 const elements = {
   workoutState: document.getElementById('workoutState'),
   startToggle: document.getElementById('toggleWorkout'),
@@ -104,7 +101,6 @@ function updateForceProfileLockState() {
 function notifyForceProfileLock() {
   forceProfileLockHintVisible = true;
   updateForceProfileLockState();
-  setStatusMessage(FORCE_PROFILE_LOCK_MESSAGE, { tone: 'error' });
 }
 
 function getForceCurveCopy(mode, intensityPercent) {

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -1246,10 +1246,10 @@ function drawWave(motor) {
   const availableWidth = circleX - circleRadius;
   const headY = topPadding + (1 - motor.normalized) * usableHeight;
 
-  ctx.lineWidth = 4;
+  ctx.lineWidth = 8;
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
-  const gradient = ctx.createLinearGradient(0, 0, circleX, 0);
+  const gradient = ctx.createLinearGradient(0, 0, circleX - circleRadius, 0);
   gradient.addColorStop(0, 'rgba(31, 139, 255, 0)');
   gradient.addColorStop(0.18, 'rgba(31, 139, 255, 0.45)');
   gradient.addColorStop(1, 'rgba(127, 255, 212, 0.95)');
@@ -1272,7 +1272,7 @@ function drawWave(motor) {
   } else {
     ctx.moveTo(0, headY);
   }
-  ctx.lineTo(circleX, headY);
+  ctx.lineTo(circleX - circleRadius, headY);
   ctx.stroke();
 
   ctx.fillStyle = 'rgba(31, 139, 255, 0.35)';

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -677,8 +677,6 @@ motors.forEach((motor) => {
     if (motor.setArmed) {
       setMotorEngagementDistance(motor, distance, { source: 'set-button' });
       disarmMotorCableSet(motor, { silent: true });
-    } else {
-      setMotorEngagementDistance(motor, distance, { source: 'simulation' });
     }
   });
   motor.baseLabel.textContent = `${motor.baseResistance} lb`;

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -1277,6 +1277,8 @@ function update(timestamp) {
       );
     }
 
+    const resistance = resolveMotorResistance(motor, engageDistance, mode);
+
     if (!setActive) {
       motor.engaged = false;
       motor.reps = 0;
@@ -1286,7 +1288,7 @@ function update(timestamp) {
       resetMotorTracking(motor, travel);
     }
 
-    motor.currentResistance = resolveMotorResistance(motor, engageDistance, mode);
+    motor.currentResistance = resistance;
 
     motor.cableLabel.textContent = travel.toFixed(1);
 

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -77,18 +77,6 @@
         </div>
         <p class="status-message" id="workoutMessage">Tap “Start Workout” to arm the set controls.</p>
       </article>
-      <article class="engagement-card" aria-label="Cable engagement distance">
-        <h3>Cable Engagement</h3>
-        <label for="engageDistance" class="slider-field">
-          <span>Engagement distance</span>
-          <input type="range" id="engageDistance" min="0" max="24" step="0.5" value="1.5" />
-        </label>
-        <p class="hint">Engage after <span id="engageDisplay">1.5</span> in of travel.</p>
-        <div class="engagement-actions">
-          <button type="button" class="ghost" id="setCableLength">Set Cable Length</button>
-          <button type="button" class="ghost" id="retractCables">Retract Cable</button>
-        </div>
-      </article>
       <article class="motor-card" data-motor="left">
         <div class="gauge-wrapper">
           <canvas class="resistance-gauge" id="leftGauge" width="320" height="320" aria-hidden="true"></canvas>
@@ -107,10 +95,23 @@
             <dd id="leftRepCount">0</dd>
           </div>
         </dl>
-        <label class="slider-field">
-          <span>Adjust resistance</span>
-          <input type="range" id="leftResistance" min="0" max="300" value="120" />
-        </label>
+        <div class="resistance-control">
+          <label class="slider-field">
+            <span>Adjust resistance</span>
+            <input type="range" id="leftResistance" min="0" max="300" value="120" />
+          </label>
+        </div>
+        <div class="motor-engagement" aria-label="Left motor cable engagement">
+          <label class="slider-field">
+            <span>Engagement distance</span>
+            <input type="range" id="leftEngageDistance" min="0" max="24" step="0.5" value="1.5" />
+          </label>
+          <p class="hint">Engage after <span id="leftEngageDisplay">1.5</span> in of travel.</p>
+          <div class="engagement-actions">
+            <button type="button" class="ghost" id="leftSetCableLength">Set Cable Length</button>
+            <button type="button" class="ghost" id="leftRetractCable">Retract Cable</button>
+          </div>
+        </div>
       </article>
 
       <article class="motor-card" data-motor="right">
@@ -131,10 +132,23 @@
             <dd id="rightRepCount">0</dd>
           </div>
         </dl>
-        <label class="slider-field">
-          <span>Adjust resistance</span>
-          <input type="range" id="rightResistance" min="0" max="300" value="120" />
-        </label>
+        <div class="resistance-control">
+          <label class="slider-field">
+            <span>Adjust resistance</span>
+            <input type="range" id="rightResistance" min="0" max="300" value="120" />
+          </label>
+        </div>
+        <div class="motor-engagement" aria-label="Right motor cable engagement">
+          <label class="slider-field">
+            <span>Engagement distance</span>
+            <input type="range" id="rightEngageDistance" min="0" max="24" step="0.5" value="1.5" />
+          </label>
+          <p class="hint">Engage after <span id="rightEngageDisplay">1.5</span> in of travel.</p>
+          <div class="engagement-actions">
+            <button type="button" class="ghost" id="rightSetCableLength">Set Cable Length</button>
+            <button type="button" class="ghost" id="rightRetractCable">Retract Cable</button>
+          </div>
+        </div>
       </article>
     </section>
 

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -187,19 +187,31 @@
       <section class="force-panel" aria-label="Force curve profiles" id="forceCurvePanel" hidden>
         <h3>Force Curve Profiles</h3>
         <div class="force-curve-group">
-          <label>
-            <span>Force curve mode (concentric)</span>
-            <select id="forceCurve">
-              <option value="linear">Linear</option>
-              <option value="chain">Chain mode</option>
-              <option value="band">Band mode</option>
-              <option value="reverse-chain">Reverse chain</option>
-            </select>
-          </label>
-          <label>
-            <span>Force curve intensity (%)</span>
-            <input type="number" id="forceCurveIntensity" min="0" max="100" step="1" value="20" />
-          </label>
+          <div class="force-curve-header">
+            <div class="force-curve-inputs">
+              <label>
+                <span>Force curve mode (concentric)</span>
+                <select id="forceCurve">
+                  <option value="linear">Linear</option>
+                  <option value="chain">Chain mode</option>
+                  <option value="band">Band mode</option>
+                  <option value="reverse-chain">Reverse chain</option>
+                </select>
+              </label>
+              <label>
+                <span>Force curve intensity (%)</span>
+                <input type="number" id="forceCurveIntensity" min="0" max="100" step="1" value="20" />
+              </label>
+            </div>
+            <button
+              class="ghost eccentric-toggle"
+              id="eccentricToggle"
+              type="button"
+              aria-expanded="false"
+            >
+              Enable eccentric profile
+            </button>
+          </div>
           <canvas
             class="force-curve-graph"
             id="forceCurveConcentric"
@@ -208,14 +220,6 @@
             aria-hidden="true"
           ></canvas>
           <p class="hint" id="forceCurveDescription">Concentric: Equal load through the pull and return.</p>
-          <button
-            class="ghost eccentric-toggle"
-            id="eccentricToggle"
-            type="button"
-            aria-expanded="false"
-          >
-            Enable eccentric profile
-          </button>
           <div class="eccentric-panel" id="eccentricPanel" hidden>
             <label>
               <span>Eccentric force curve</span>

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -79,7 +79,7 @@
       </article>
       <article class="motor-card" data-motor="left">
         <div class="gauge-wrapper">
-          <canvas class="resistance-gauge" id="leftGauge" width="320" height="320" aria-hidden="true"></canvas>
+          <canvas class="resistance-gauge" id="leftGauge" width="540" height="540" aria-hidden="true"></canvas>
           <div class="gauge-center">
             <span class="motor-name">Left</span>
             <span class="current-resistance" id="leftCurrentResistance">0 lb</span>
@@ -116,7 +116,7 @@
 
       <article class="motor-card" data-motor="right">
         <div class="gauge-wrapper">
-          <canvas class="resistance-gauge" id="rightGauge" width="320" height="320" aria-hidden="true"></canvas>
+          <canvas class="resistance-gauge" id="rightGauge" width="540" height="540" aria-hidden="true"></canvas>
           <div class="gauge-center">
             <span class="motor-name">Right</span>
             <span class="current-resistance" id="rightCurrentResistance">0 lb</span>

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -186,6 +186,9 @@
       </section>
       <section class="force-panel" aria-label="Force curve profiles" id="forceCurvePanel" hidden>
         <h3>Force Curve Profiles</h3>
+        <p class="hint lock-hint" id="forceCurveLockHint" hidden aria-live="polite">
+          Retract both cables to or below their engagement distance to adjust these settings.
+        </p>
         <div class="force-curve-group">
           <div class="force-curve-header">
             <div class="force-curve-inputs">

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -86,6 +86,7 @@
         <p class="hint">Engage after <span id="engageDisplay">1.5</span> in of travel.</p>
         <div class="engagement-actions">
           <button type="button" class="ghost" id="setCableLength">Set Cable Length</button>
+          <button type="button" class="ghost" id="retractCables">Retract Cable</button>
         </div>
       </article>
       <article class="motor-card" data-motor="left">

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -190,7 +190,7 @@
           <div class="force-curve-header">
             <div class="force-curve-inputs">
               <label>
-                <span>Force curve mode (concentric)</span>
+                <span>Force curve mode</span>
                 <select id="forceCurve">
                   <option value="linear">Linear</option>
                   <option value="chain">Chain mode</option>
@@ -219,7 +219,7 @@
             height="220"
             aria-hidden="true"
           ></canvas>
-          <p class="hint" id="forceCurveDescription">Concentric: Equal load through the pull and return.</p>
+          <p class="hint" id="forceCurveDescription">Force curve: Equal load through the pull and return.</p>
           <div class="eccentric-panel" id="eccentricPanel" hidden>
             <label>
               <span>Eccentric force curve</span>

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -102,11 +102,11 @@
           </label>
         </div>
         <div class="motor-engagement" aria-label="Left motor cable engagement">
-          <label class="slider-field">
-            <span>Engagement distance</span>
-            <input type="range" id="leftEngageDistance" min="0" max="24" step="0.5" value="1.5" />
-          </label>
-          <p class="hint">Engage after <span id="leftEngageDisplay">1.5</span> in of travel.</p>
+          <div class="engagement-readout" aria-live="polite">
+            <span class="label">Engagement distance</span>
+            <span class="value" id="leftEngageDisplay">1.0 in</span>
+          </div>
+          <p class="hint">Weight engages at <span id="leftEngageThreshold">2.0 in</span>.</p>
           <div class="engagement-actions">
             <button type="button" class="ghost" id="leftSetCableLength">Set Cable Length</button>
             <button type="button" class="ghost" id="leftRetractCable">Retract Cable</button>
@@ -139,11 +139,11 @@
           </label>
         </div>
         <div class="motor-engagement" aria-label="Right motor cable engagement">
-          <label class="slider-field">
-            <span>Engagement distance</span>
-            <input type="range" id="rightEngageDistance" min="0" max="24" step="0.5" value="1.5" />
-          </label>
-          <p class="hint">Engage after <span id="rightEngageDisplay">1.5</span> in of travel.</p>
+          <div class="engagement-readout" aria-live="polite">
+            <span class="label">Engagement distance</span>
+            <span class="value" id="rightEngageDisplay">1.0 in</span>
+          </div>
+          <p class="hint">Weight engages at <span id="rightEngageThreshold">2.0 in</span>.</p>
           <div class="engagement-actions">
             <button type="button" class="ghost" id="rightSetCableLength">Set Cable Length</button>
             <button type="button" class="ghost" id="rightRetractCable">Retract Cable</button>
@@ -175,11 +175,11 @@
           <div class="sim-slider-group">
             <label class="sim-slider">
               <span>Left cable length</span>
-              <input type="range" id="leftSim" min="0" max="24" step="0.1" value="0" />
+              <input type="range" id="leftSim" min="1" max="24" step="0.1" value="1" />
             </label>
             <label class="sim-slider">
               <span>Right cable length</span>
-              <input type="range" id="rightSim" min="0" max="24" step="0.1" value="0" />
+              <input type="range" id="rightSim" min="1" max="24" step="0.1" value="1" />
             </label>
           </div>
         </section>

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -261,15 +261,19 @@ body {
 
 .resistance-overview {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
   gap: clamp(20px, 3vw, 32px);
-  align-items: start;
+  align-items: stretch;
 }
 
 
 .resistance-overview > * {
   width: 100%;
   justify-self: stretch;
+}
+
+.status-card {
+  grid-column: 1 / -1;
 }
 
 .status-card {
@@ -470,6 +474,8 @@ button.is-pulsing {
   overflow: hidden;
   justify-items: center;
   width: 100%;
+  min-height: 100%;
+  align-content: start;
 }
 
 .motor-card::before {
@@ -488,7 +494,7 @@ button.is-pulsing {
 
 .gauge-wrapper {
   position: relative;
-  width: min(100%, clamp(360px, 60vw, 540px));
+  width: min(100%, clamp(320px, 45vw, 480px));
   aspect-ratio: 1 / 1;
   justify-self: center;
 }
@@ -1052,6 +1058,14 @@ button.is-pulsing {
 
   .hud-corner.top-right {
     justify-content: flex-end;
+  }
+
+  .resistance-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .status-card {
+    grid-column: auto;
   }
 }
 

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -355,6 +355,7 @@ body {
   accent-color: var(--accent);
 }
 
+
 .motor-engagement {
   margin: 28px auto 0;
   width: min(100%, 620px);
@@ -363,21 +364,28 @@ body {
   text-align: center;
 }
 
-.motor-engagement .slider-field {
+.motor-engagement .engagement-readout {
   background: rgba(10, 16, 28, 0.72);
   border-radius: 18px;
   border: 1px solid rgba(62, 90, 118, 0.4);
-  padding: 18px 24px;
+  padding: 20px 28px;
+  display: grid;
+  gap: 6px;
+}
+
+.motor-engagement .engagement-readout .label {
+  font-family: "Rajdhani", sans-serif;
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-family: "Rajdhani", sans-serif;
+  color: var(--text-muted);
 }
 
-.motor-engagement .slider-field input[type="range"] {
-  width: 100%;
-  height: 10px;
-  accent-color: var(--accent);
+.motor-engagement .engagement-readout .value {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.45rem;
+  letter-spacing: 0.1em;
+  color: #7fffd4;
 }
 
 .motor-engagement .hint {
@@ -386,6 +394,24 @@ body {
 
 .motor-engagement .engagement-actions {
   justify-content: center;
+}
+
+button.is-pulsing {
+  animation: pulse-blue 1.2s ease-in-out infinite;
+  box-shadow: 0 0 0 0 rgba(64, 160, 255, 0.45);
+  border-color: rgba(64, 160, 255, 0.75) !important;
+}
+
+@keyframes pulse-blue {
+  0% {
+    box-shadow: 0 0 0 0 rgba(64, 160, 255, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 16px rgba(64, 160, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(64, 160, 255, 0);
+  }
 }
 
 .status-header {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -344,6 +344,8 @@ body {
   letter-spacing: 0.12em;
   font-size: 1rem;
   text-align: center;
+  justify-items: center;
+  align-items: center;
   width: min(100%, 520px);
 }
 
@@ -554,10 +556,14 @@ button.is-pulsing {
   gap: 12px;
 }
 
+
 .force-curve-group {
   display: grid;
   gap: 16px;
   max-width: 620px;
+  justify-items: center;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .force-curve-group label {
@@ -567,6 +573,8 @@ button.is-pulsing {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-family: "Rajdhani", sans-serif;
+  justify-items: center;
+  width: min(100%, 420px);
 }
 
 .force-curve-group select,
@@ -582,6 +590,7 @@ button.is-pulsing {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   transition: border-color var(--transition), box-shadow var(--transition);
+  text-align: center;
 }
 
 .force-curve-group select:focus,
@@ -602,7 +611,7 @@ button.is-pulsing {
 }
 
 .eccentric-toggle {
-  justify-self: start;
+  justify-self: center;
   padding: 8px 16px;
   font-size: 0.8rem;
   letter-spacing: 0.08em;
@@ -617,6 +626,8 @@ button.is-pulsing {
   border: 1px solid var(--border);
   background: rgba(6, 12, 22, 0.85);
   box-shadow: inset 0 0 0 1px rgba(31, 139, 255, 0.08);
+  justify-items: center;
+  text-align: center;
 }
 
 .eccentric-panel[hidden] {
@@ -846,6 +857,11 @@ button.is-pulsing {
   gap: 14px;
 }
 
+.force-panel {
+  justify-items: center;
+  text-align: center;
+}
+
 .force-panel h3,
 .log-panel h3,
 .selector-panel h3 {
@@ -854,6 +870,14 @@ button.is-pulsing {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.force-panel h3 {
+  justify-self: center;
+}
+
+.force-panel .hint {
+  text-align: center;
 }
 
 .log-list {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -330,8 +330,7 @@ body {
 
 .resistance-control {
   margin: 28px auto 0;
-  width: 100%;
-  max-width: 620px;
+  width: min(100%, 620px);
   display: flex;
   justify-content: center;
   justify-self: center;
@@ -351,8 +350,8 @@ body {
   text-align: center;
   justify-items: center;
   align-items: center;
-  width: 100%;
-  max-width: 520px;
+  width: min(100%, 520px);
+  margin: 0 auto;
 }
 
 .resistance-control .slider-field span {
@@ -369,8 +368,7 @@ body {
 
 .motor-engagement {
   margin: 28px auto 0;
-  width: 100%;
-  max-width: 620px;
+  width: min(100%, 620px);
   display: grid;
   gap: 14px;
   text-align: center;
@@ -465,6 +463,7 @@ button.is-pulsing {
   gap: 22px;
   position: relative;
   overflow: hidden;
+  justify-items: center;
 }
 
 .motor-card::before {
@@ -529,6 +528,12 @@ button.is-pulsing {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
+  justify-self: stretch;
+}
+
+.motor-meta dt,
+.motor-meta dd {
+  text-align: left;
 }
 
 .motor-meta dt {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -261,9 +261,16 @@ body {
 
 .resistance-overview {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 380px));
   gap: 24px;
   align-items: start;
+  justify-content: center;
+}
+
+.resistance-overview .motor-card {
+  justify-self: center;
+  width: 100%;
+  max-width: 380px;
 }
 
 .status-card {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -595,9 +595,24 @@ button.is-pulsing {
   display: grid;
   gap: 16px;
   max-width: 620px;
-  justify-items: center;
+  justify-items: stretch;
   margin: 0 auto;
   text-align: center;
+}
+
+.force-curve-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+}
+
+.force-curve-inputs {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  flex: 1 1 auto;
 }
 
 .force-curve-group label {
@@ -609,6 +624,12 @@ button.is-pulsing {
   font-family: "Rajdhani", sans-serif;
   justify-items: center;
   width: min(100%, 420px);
+}
+
+.force-curve-inputs label {
+  justify-items: stretch;
+  text-align: left;
+  width: 100%;
 }
 
 .force-curve-group select,
@@ -650,6 +671,22 @@ button.is-pulsing {
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.force-curve-header .eccentric-toggle {
+  align-self: center;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .force-curve-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .force-curve-header .eccentric-toggle {
+    width: 100%;
+  }
 }
 
 .eccentric-panel {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -66,7 +66,7 @@ body {
   width: min(100%, 1080px);
   min-height: 1920px;
   margin: 0 auto;
-  padding: clamp(150px, 18vw, 220px) clamp(20px, 4vw, 32px) 60px;
+  padding: clamp(75px, 9vw, 110px) clamp(20px, 4vw, 32px) 60px;
   display: flex;
   flex-direction: column;
   gap: 28px;

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -854,6 +854,11 @@ button.is-pulsing {
   color: var(--text-muted);
 }
 
+.status-message.is-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
 .visual-panel {
   background: linear-gradient(160deg, rgba(9, 16, 27, 0.92), rgba(4, 7, 15, 0.9));
   border-radius: var(--card-radius);

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -938,6 +938,31 @@ button.is-pulsing {
   text-align: center;
 }
 
+.force-panel.is-locked .force-curve-group {
+  opacity: 0.55;
+  filter: saturate(0.7);
+  transition: opacity var(--transition), filter var(--transition);
+}
+
+.force-panel.is-locked .force-curve-group select,
+.force-panel.is-locked .force-curve-group input,
+.force-panel.is-locked .force-curve-group button {
+  cursor: not-allowed;
+}
+
+.force-panel .lock-hint {
+  margin: 0;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 79, 109, 0.32);
+  background: rgba(255, 79, 109, 0.12);
+  color: var(--danger);
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-family: "Rajdhani", sans-serif;
+}
+
 .force-panel h3,
 .log-panel h3,
 .selector-panel h3 {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -318,11 +318,73 @@ body {
 .engagement-actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 }
 
 .engagement-actions button {
-  flex: 0 1 200px;
+  flex: 0 1 220px;
+  justify-content: center;
+}
+
+.resistance-control {
+  margin: 28px auto 0;
+  width: min(100%, 620px);
+}
+
+.resistance-control .slider-field {
+  background: linear-gradient(160deg, rgba(10, 16, 28, 0.94), rgba(6, 11, 20, 0.9));
+  border-radius: 999px;
+  border: 1px solid rgba(62, 90, 118, 0.55);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+  padding: 22px 32px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.resistance-control .slider-field span {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.05rem;
+}
+
+.resistance-control .slider-field input[type="range"] {
+  width: 100%;
+  height: 14px;
+  accent-color: var(--accent);
+}
+
+.motor-engagement {
+  margin: 28px auto 0;
+  width: min(100%, 620px);
+  display: grid;
+  gap: 14px;
+  text-align: center;
+}
+
+.motor-engagement .slider-field {
+  background: rgba(10, 16, 28, 0.72);
+  border-radius: 18px;
+  border: 1px solid rgba(62, 90, 118, 0.4);
+  padding: 18px 24px;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: "Rajdhani", sans-serif;
+}
+
+.motor-engagement .slider-field input[type="range"] {
+  width: 100%;
+  height: 10px;
+  accent-color: var(--accent);
+}
+
+.motor-engagement .hint {
+  font-size: 0.88rem;
+}
+
+.motor-engagement .engagement-actions {
   justify-content: center;
 }
 

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -261,20 +261,18 @@ body {
 
 .resistance-overview {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 380px));
-  gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(20px, 3vw, 32px);
   align-items: start;
-  justify-content: center;
 }
 
-.resistance-overview .motor-card {
-  justify-self: center;
+
+.resistance-overview > * {
   width: 100%;
-  max-width: 380px;
+  justify-self: stretch;
 }
 
 .status-card {
-  grid-column: 1 / -1;
   background: linear-gradient(150deg, rgba(8, 14, 25, 0.94), rgba(4, 7, 15, 0.9));
   border-radius: var(--card-radius);
   border: 1px solid var(--border);
@@ -471,6 +469,7 @@ button.is-pulsing {
   position: relative;
   overflow: hidden;
   justify-items: center;
+  width: 100%;
 }
 
 .motor-card::before {
@@ -489,7 +488,7 @@ button.is-pulsing {
 
 .gauge-wrapper {
   position: relative;
-  width: min(100%, 320px);
+  width: min(100%, clamp(360px, 60vw, 540px));
   aspect-ratio: 1 / 1;
   justify-self: center;
 }
@@ -504,8 +503,8 @@ button.is-pulsing {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 62%;
-  height: 62%;
+  width: min(68%, 360px);
+  height: min(68%, 360px);
   transform: translate(-50%, -50%);
   border-radius: 50%;
   display: grid;
@@ -521,12 +520,12 @@ button.is-pulsing {
   font-family: "Rajdhani", sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  font-size: 1rem;
+  font-size: clamp(1rem, 2.1vw, 1.35rem);
   color: var(--text-muted);
 }
 
 .current-resistance {
-  font-size: clamp(1.6rem, 2.4vw, 2.3rem);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
   font-weight: 600;
 }
 

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -327,11 +327,14 @@ body {
   justify-content: center;
 }
 
+
 .resistance-control {
   margin: 28px auto 0;
   width: 100%;
+  max-width: 620px;
   display: flex;
   justify-content: center;
+  justify-self: center;
 }
 
 .resistance-control .slider-field {
@@ -348,7 +351,8 @@ body {
   text-align: center;
   justify-items: center;
   align-items: center;
-  width: min(100%, 520px);
+  width: 100%;
+  max-width: 520px;
 }
 
 .resistance-control .slider-field span {
@@ -365,11 +369,13 @@ body {
 
 .motor-engagement {
   margin: 28px auto 0;
-  width: min(100%, 620px);
+  width: 100%;
+  max-width: 620px;
   display: grid;
   gap: 14px;
   text-align: center;
   justify-items: center;
+  justify-self: center;
 }
 
 .motor-engagement .engagement-readout {
@@ -379,7 +385,9 @@ body {
   padding: 20px 28px;
   display: grid;
   gap: 6px;
-  width: min(100%, 520px);
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
 }
 
 .motor-engagement .hint {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -329,7 +329,9 @@ body {
 
 .resistance-control {
   margin: 28px auto 0;
-  width: min(100%, 620px);
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .resistance-control .slider-field {
@@ -342,6 +344,7 @@ body {
   letter-spacing: 0.12em;
   font-size: 1rem;
   text-align: center;
+  width: min(100%, 520px);
 }
 
 .resistance-control .slider-field span {

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -335,6 +335,8 @@ body {
 }
 
 .resistance-control .slider-field {
+  display: grid;
+  gap: 16px;
   background: linear-gradient(160deg, rgba(10, 16, 28, 0.94), rgba(6, 11, 20, 0.9));
   border-radius: 999px;
   border: 1px solid rgba(62, 90, 118, 0.55);
@@ -367,6 +369,7 @@ body {
   display: grid;
   gap: 14px;
   text-align: center;
+  justify-items: center;
 }
 
 .motor-engagement .engagement-readout {
@@ -376,6 +379,12 @@ body {
   padding: 20px 28px;
   display: grid;
   gap: 6px;
+  width: min(100%, 520px);
+}
+
+.motor-engagement .hint {
+  max-width: 520px;
+  margin: 0 auto;
 }
 
 .motor-engagement .engagement-readout .label {


### PR DESCRIPTION
## Summary
- enlarge the wave resistance markers and center them within their lanes
- synchronize the engagement distance with motor travel sliders in both directions
- add a retract cable control that pulls cables to the 1 in stop at 0.2 mph

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d74b272bf883278873cba2b6eec7c2