### PR TITLE
Add engagement sliders and enlarge resistance controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project layout
+- `dragon_gym/` hosts the single-page simulator UI:
+  - `index.html` wires the DOM and imports `styles.css` and `app.js` directly without a bundler.
+  - `styles.css` contains all layout and visual design rules.
+  - `app.js` holds the workout simulation logic, DOM interactions, and drawing utilities for the gauges.
+- Static assets (SVGs, images) live under `dragon_gym/assets/`.
+
+## Coding style
+- Follow the prevailing two-space indentation in HTML, CSS, and JavaScript files.
+- Stay with vanilla JavaScript—do not introduce build steps, third-party frameworks, or module systems.
+- Prefer `const` for values that are not reassigned and `let` otherwise; avoid `var` entirely.
+- Keep helper functions defined at top level (function declarations) like the existing utilities unless a closure or factory pattern is needed.
+- When extending DOM lookups, add new IDs or classes to the central `elements` map in `app.js` and gate DOM operations with null checks as shown.
+- Preserve accessibility attributes (`aria-*`, `role`, live regions) when adjusting markup.
+
+## CSS conventions
+- Reuse existing custom properties (`--accent`, `--card-radius`, etc.) before adding new colors or sizes.
+- Keep selectors scoped to existing structural classes (e.g., `.motor-card`, `.status-card`) and prefer modifiers (`.is-locked`) over deeply nested selectors when toggling state from JavaScript.
+- Maintain responsive behavior—leverage `clamp()` and flex/grid utilities consistent with the current layout.
+
+## Testing & validation
+- Run `node --check dragon_gym/app.js` after JavaScript changes to verify syntax.
+- For visual tweaks that do not affect JavaScript logic, mention when tests are intentionally skipped.
+
+## Git & PR hygiene
+- Group related changes per feature/fix and keep commit messages descriptive.
+- Update documentation or inline comments if behavior changes in a way that future contributors should know.

--- a/dragon_gym/app.js
+++ b/dragon_gym/app.js
@@ -6,7 +6,14 @@ const REP_SPAN_THRESHOLD = 3;
 const MOVEMENT_EPSILON = 0.05;
 const DEFAULT_REP_TARGET = 12;
 const TRAIL_LENGTH = 600;
-
+const INCHES_PER_MILE = 63360;
+const SECONDS_PER_HOUR = 3600;
+const RETRACTION_SPEED_MPH = 0.2;
+const RETRACTION_SPEED_IPS =
+  (RETRACTION_SPEED_MPH * INCHES_PER_MILE) / SECONDS_PER_HOUR;
+const SIM_SLIDER_STEP = 0.1;
+const DEFAULT_RETRACTION_BOTTOM = 1;
+const WEIGHT_ENGAGE_OFFSET = 1;
 const elements = {
   workoutState: document.getElementById('workoutState'),
   startToggle: document.getElementById('toggleWorkout'),
@@ -28,9 +35,7 @@ const elements = {
   eccentricDescription: document.getElementById('eccentricCurveDescription'),
   forceCurveIntensity: document.getElementById('forceCurveIntensity'),
   forcePanel: document.getElementById('forceCurvePanel'),
-  engageSlider: document.getElementById('engageDistance'),
-  engageDisplay: document.getElementById('engageDisplay'),
-  setCableButton: document.getElementById('setCableLength'),
+  forceLockHint: document.getElementById('forceCurveLockHint'),
   powerToggle: document.getElementById('powerToggle'),
   motorToggle: document.getElementById('motorToggle'),
   logList: document.getElementById('workoutLogList'),
@@ -39,6 +44,64 @@ const elements = {
   exerciseImagePlaceholder: document.getElementById('exerciseImagePlaceholder'),
   exerciseVideoPlaceholder: document.getElementById('exerciseVideoPlaceholder'),
 };
+
+function setStatusMessage(message, options = {}) {
+  if (!elements.message) return;
+  const { tone = 'info' } = options;
+  elements.message.textContent = message;
+  if (tone === 'error') {
+    elements.message.classList.add('is-error');
+  } else {
+    elements.message.classList.remove('is-error');
+  }
+}
+
+function motorBeyondEngagement(motor) {
+  if (!motor) {
+    return false;
+  }
+  const travel = motor.normalized * MAX_TRAVEL_INCHES;
+  return travel > motor.engagementDistance + MOVEMENT_EPSILON;
+}
+
+let forceProfileLockHintVisible = false;
+
+function updateForceProfileLockState() {
+  const locked = motors.some((motor) => motorBeyondEngagement(motor));
+
+  if (elements.forcePanel) {
+    elements.forcePanel.classList.toggle('is-locked', locked);
+  }
+
+  if (elements.forceLockHint) {
+    if (!locked) {
+      forceProfileLockHintVisible = false;
+    }
+    elements.forceLockHint.hidden = !(locked && forceProfileLockHintVisible);
+  }
+
+  const controls = [
+    elements.forceSelect,
+    elements.forceCurveIntensity,
+    elements.eccentricToggle,
+    elements.eccentricSelect,
+  ];
+  controls.forEach((control) => {
+    if (!control) return;
+    if (locked) {
+      control.setAttribute('aria-disabled', 'true');
+    } else {
+      control.removeAttribute('aria-disabled');
+    }
+  });
+
+  return locked;
+}
+
+function notifyForceProfileLock() {
+  forceProfileLockHintVisible = true;
+  updateForceProfileLockState();
+}
 
 function getForceCurveCopy(mode, intensityPercent) {
   const pct = Math.round(intensityPercent);
@@ -92,6 +155,9 @@ let eccentricOverrideEnabled = false;
 let forceCurveIntensity = 20;
 const workoutLog = [];
 
+let lastForceCurveMode = elements.forceSelect ? elements.forceSelect.value : 'linear';
+let lastEccentricMode = elements.eccentricSelect ? elements.eccentricSelect.value : 'eccentric';
+
 const exerciseCatalog = {
   'incline-bench': 'Incline Bench',
   'weighted-pullups': 'Weighted Pull Ups',
@@ -113,10 +179,15 @@ function createMotor(id, refs) {
 
   const slider = document.getElementById(refs.sliderId);
   const simSlider = document.getElementById(refs.simId);
+  const engagementSlider = document.getElementById(`${id}EngagementSlider`);
   const currentLabel = document.getElementById(refs.currentId);
   const baseLabel = document.getElementById(refs.baseId);
   const repsLabel = document.getElementById(refs.repsId);
   const cableLabel = document.getElementById(refs.cableId);
+  const engageDisplay = document.getElementById(`${id}EngageDisplay`);
+  const engageThresholdDisplay = document.getElementById(`${id}EngageThreshold`);
+  const setCableButton = document.getElementById(`${id}SetCableLength`);
+  const retractCableButton = document.getElementById(`${id}RetractCable`);
 
   const initialTravel = Number(simSlider.value);
   const normalized = Math.max(0, Math.min(1, initialTravel / MAX_TRAVEL_INCHES));
@@ -130,22 +201,36 @@ function createMotor(id, refs) {
     waveCtx,
     slider,
     simSlider,
+    engagementSlider,
     currentLabel,
     baseLabel,
     repsLabel,
     cableLabel,
+    engageDisplay,
+    engageThresholdDisplay,
+    setCableButton,
+    retractCableButton,
     baseResistance: Number(slider.value),
     currentResistance: 0,
     reps: 0,
     engaged: false,
+    engagementDistance: Math.max(DEFAULT_RETRACTION_BOTTOM, travelInches),
+    setArmed: false,
+    retractionActive: false,
+    retractionTarget: DEFAULT_RETRACTION_BOTTOM,
+    retractionSpeed: RETRACTION_SPEED_IPS,
     normalized,
-    direction: 0,
+    direction: 1,
     trail: new Array(TRAIL_LENGTH).fill(normalized),
     lastTravel: travelInches,
     phase: 'idle',
     lastPeak: travelInches,
     lastTrough: travelInches,
     repCounted: false,
+    resistanceSuspended: false,
+    armedTravelStart: null,
+    forceDirection: 1,
+    lastForceTravel: travelInches,
   };
 }
 
@@ -203,23 +288,238 @@ function resetMotorTracking(motor, travel) {
   motor.lastTrough = travel;
   motor.lastTravel = travel;
   motor.direction = 0;
+  motor.lastForceTravel = travel;
 }
 
 function calculateEngagementProgress(travel, engageDistance) {
-  const clampedStart = Math.max(0, Math.min(MAX_TRAVEL_INCHES, engageDistance));
-  const rampEnd = Math.min(MAX_TRAVEL_INCHES, clampedStart + ENGAGEMENT_RAMP_INCHES);
-  if (travel <= clampedStart) {
+  const engageStart = Math.max(
+    0,
+    Math.min(MAX_TRAVEL_INCHES, engageDistance + WEIGHT_ENGAGE_OFFSET)
+  );
+  const rampEnd = Math.min(MAX_TRAVEL_INCHES, engageStart + ENGAGEMENT_RAMP_INCHES);
+  if (travel <= engageStart) {
     return 0;
   }
   if (travel >= rampEnd) {
     return 1;
   }
-  const span = Math.max(0.001, rampEnd - clampedStart);
-  return Math.max(0, Math.min(1, (travel - clampedStart) / span));
+  const span = Math.max(0.001, rampEnd - engageStart);
+  return Math.max(0, Math.min(1, (travel - engageStart) / span));
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function quantize(value, step) {
+  if (!step) return value;
+  return Math.round(value / step) * step;
+}
+
+function formatMotorLabel(id) {
+  if (!id) return 'System';
+  return `${id.charAt(0).toUpperCase()}${id.slice(1)}`;
+}
+
+function toggleButtonPulse(button, active) {
+  if (!button) return;
+  const shouldPulse = Boolean(active);
+  button.classList.toggle('is-pulsing', shouldPulse);
+  if (shouldPulse) {
+    button.setAttribute('aria-busy', 'true');
+  } else {
+    button.removeAttribute('aria-busy');
+  }
+}
+
+function setMotorResistanceSuspended(motor, suspended) {
+  if (!motor) return;
+  motor.resistanceSuspended = Boolean(suspended);
+  if (motor.resistanceSuspended) {
+    motor.currentResistance = 0;
+    drawGauge(motor);
+  } else {
+    refreshMotorResistance(motor);
+  }
+}
+
+
+function renderMotorEngagement(motor, options = {}) {
+  if (!motor) return;
+  const { preview } = options;
+  const distanceSource =
+    preview !== undefined ? preview : motor.engagementDistance;
+  const clampedValue = clamp(
+    distanceSource,
+    DEFAULT_RETRACTION_BOTTOM,
+    MAX_TRAVEL_INCHES
+  );
+  const formatted = `${clampedValue.toFixed(1)} in`;
+  const threshold = Math.min(
+    MAX_TRAVEL_INCHES,
+    clampedValue + WEIGHT_ENGAGE_OFFSET
+  );
+  const thresholdFormatted = `${threshold.toFixed(1)} in`;
+  if (motor.engageDisplay) {
+    motor.engageDisplay.textContent = formatted;
+  }
+  if (motor.engageThresholdDisplay) {
+    motor.engageThresholdDisplay.textContent = thresholdFormatted;
+  }
+}
+
+function announceMotorEngagementChange(motor, distance, source) {
+  if (!elements.message || !motor) return;
+  const clampedDistance = clamp(
+    distance,
+    DEFAULT_RETRACTION_BOTTOM,
+    MAX_TRAVEL_INCHES
+  );
+  const actualEngage = Math.min(
+    MAX_TRAVEL_INCHES,
+    clampedDistance + WEIGHT_ENGAGE_OFFSET
+  );
+  const engageNote = ` Weight engages at ${actualEngage.toFixed(1)} in.`;
+  const label = formatMotorLabel(motor.id);
+  let message;
+  switch (source) {
+    case 'set-button':
+      message = `${label} cable length locked at ${clampedDistance.toFixed(1)} in.`;
+      break;
+    case 'simulation':
+      message = `${label} cable length synchronized to ${clampedDistance.toFixed(
+        1
+      )} in from the simulator.`;
+      break;
+    case 'retraction':
+      message = `${label} cable retracted to ${clampedDistance.toFixed(1)} in.`;
+      break;
+    case 'engagement':
+    default:
+      message = `${label} engagement distance set to ${clampedDistance.toFixed(
+        1
+      )} in.`;
+      break;
+  }
+  if (source !== 'retraction') {
+    message = `${message}${engageNote}`;
+  }
+  setStatusMessage(message);
+}
+
+function setMotorEngagementDistance(motor, distance, options = {}) {
+  if (!motor) return null;
+  const { skipSimSync = false, source = 'engagement', announce = true } = options;
+  const clamped = clamp(distance, DEFAULT_RETRACTION_BOTTOM, MAX_TRAVEL_INCHES);
+  const quantized = quantize(clamped, SIM_SLIDER_STEP);
+  motor.engagementDistance = quantized;
+  renderMotorEngagement(motor);
+  if (motor.engagementSlider) {
+    motor.engagementSlider.value = quantized.toFixed(1);
+  }
+  refreshMotorResistance(motor);
+
+  if (!skipSimSync && motor.simSlider) {
+    motor.simSlider.value = quantized.toFixed(1);
+  }
+
+  if (announce) {
+    announceMotorEngagementChange(motor, quantized, source);
+  }
+
+  updateForceProfileLockState();
+
+  return quantized;
+}
+
+function disarmMotorCableSet(motor, options = {}) {
+  if (!motor || !motor.setArmed) return;
+  const { silent = false } = options;
+  motor.setArmed = false;
+  motor.armedTravelStart = null;
+  setMotorResistanceSuspended(motor, false);
+  toggleButtonPulse(motor.setCableButton, false);
+  if (!silent) {
+    const label = formatMotorLabel(motor.id);
+    setStatusMessage(`${label} cable length arming canceled.`);
+  }
+}
+
+function toggleMotorCableSet(motor) {
+  if (!motor || !powerOn) return;
+  if (motor.setArmed) {
+    disarmMotorCableSet(motor);
+    return;
+  }
+  const label = formatMotorLabel(motor.id);
+  if (motor.retractionActive) {
+    setStatusMessage(
+      `${label} cable is retracting. Wait for it to reach ${DEFAULT_RETRACTION_BOTTOM.toFixed(
+        1
+      )} in before arming.`,
+      { tone: 'error' }
+    );
+    return;
+  }
+  const current = Number(motor.simSlider.value || 0);
+  const tolerance = SIM_SLIDER_STEP / 2;
+  if (current > DEFAULT_RETRACTION_BOTTOM + tolerance) {
+    setStatusMessage(
+      `${label} cable must be fully retracted to ${DEFAULT_RETRACTION_BOTTOM.toFixed(
+        1
+      )} in before setting length.`,
+      { tone: 'error' }
+    );
+    return;
+  }
+
+  motor.setArmed = true;
+  motor.armedTravelStart = current;
+  setMotorResistanceSuspended(motor, true);
+  toggleButtonPulse(motor.setCableButton, true);
+  setStatusMessage(
+    `${label} cable length armed. Adjust the motor travel slider and release after at least 1.0 in of travel to lock it.`,
+    { tone: 'info' }
+  );
+}
+
+function markRetractActive(motor, active) {
+  if (!motor || !motor.retractCableButton) return;
+  toggleButtonPulse(motor.retractCableButton, active);
+}
+
+function startMotorRetraction(motor) {
+  if (!powerOn || !motor) return false;
+  if (motor.retractionActive) return false;
+  disarmMotorCableSet(motor, { silent: true });
+  const current = Number(motor.simSlider.value || 0);
+  if (current <= DEFAULT_RETRACTION_BOTTOM + SIM_SLIDER_STEP / 2) {
+    const label = formatMotorLabel(motor.id);
+    setStatusMessage(
+      `${label} control reports cable already at the retraction stop.`,
+      { tone: 'info' }
+    );
+    return false;
+  }
+
+  motor.retractionActive = true;
+  motor.retractionTarget = DEFAULT_RETRACTION_BOTTOM;
+  motor.retractionSpeed = RETRACTION_SPEED_IPS;
+  markRetractActive(motor, true);
+
+  const label = formatMotorLabel(motor.id);
+  setStatusMessage(
+    `${label} cable retracting to ${motor.retractionTarget.toFixed(1)} in at ${RETRACTION_SPEED_MPH.toFixed(
+      1
+    )} mph.`,
+    { tone: 'info' }
+  );
+
+  return true;
 }
 
 function resolveMotorResistance(motor, engageDistance, mode) {
-  if (!powerOn || !motorsRunning) {
+  if (!powerOn || !motorsRunning || motor.resistanceSuspended) {
     return 0;
   }
 
@@ -229,17 +529,15 @@ function resolveMotorResistance(motor, engageDistance, mode) {
     return 0;
   }
 
-  const derivative = motor.direction || 1;
-  const multiplier = computeForceMultiplier(mode, motor.normalized, derivative);
+  const direction = motor.forceDirection || motor.direction || 1;
+  const multiplier = computeForceMultiplier(mode, motor.normalized, direction);
   const applied = motor.baseResistance * rampProgress * multiplier;
   return Math.min(MAX_RESISTANCE, Math.max(0, applied));
 }
 
 function refreshMotorResistance(motor) {
   if (!motor) return;
-  const engageDistance = elements.engageSlider
-    ? Number(elements.engageSlider.value)
-    : 0;
+  const engageDistance = motor.engagementDistance;
   const mode = elements.forceSelect ? elements.forceSelect.value : 'linear';
   motor.currentResistance = resolveMotorResistance(motor, engageDistance, mode);
   drawGauge(motor);
@@ -247,11 +545,6 @@ function refreshMotorResistance(motor) {
 
 function refreshAllMotorResistances() {
   motors.forEach((motor) => refreshMotorResistance(motor));
-}
-
-function updateEngageDisplay() {
-  elements.engageDisplay.textContent = Number(elements.engageSlider.value).toFixed(1);
-  refreshAllMotorResistances();
 }
 
 function updateSetToggleAppearance() {
@@ -301,7 +594,7 @@ function toggleWorkout() {
       elements.workoutState.classList.remove('active');
       elements.workoutState.textContent = 'Workout Not Started';
     }
-    elements.message.textContent = 'Tap “Start Workout” to arm the set controls.';
+    setStatusMessage('Tap “Start Workout” to arm the set controls.');
     eccentricOverrideEnabled = false;
     if (elements.eccentricToggle) {
       elements.eccentricToggle.textContent = 'Enable eccentric profile';
@@ -319,7 +612,7 @@ function toggleWorkout() {
       elements.workoutState.classList.add('active');
       elements.workoutState.textContent = 'Workout Started';
     }
-    elements.message.textContent = 'Press “Start Set” to begin counting reps.';
+    setStatusMessage('Press “Start Set” to begin counting reps.');
     updateStatuses();
     requestAnimationFrame(() => {
       syncForceCurveCanvasSizes();
@@ -333,7 +626,14 @@ function toggleWorkout() {
 
 elements.startToggle.addEventListener('click', toggleWorkout);
 
-elements.forceSelect.addEventListener('change', () => {
+elements.forceSelect.addEventListener('change', (event) => {
+  if (updateForceProfileLockState()) {
+    event.target.value = lastForceCurveMode;
+    notifyForceProfileLock();
+    return;
+  }
+
+  lastForceCurveMode = elements.forceSelect.value;
   updateForceCurveDescriptions();
   updateForceCurveLabel();
   redrawForceCurves();
@@ -342,13 +642,26 @@ elements.forceSelect.addEventListener('change', () => {
 
 if (elements.forceCurveIntensity) {
   setForceCurveIntensity(elements.forceCurveIntensity.value || forceCurveIntensity);
-  elements.forceCurveIntensity.addEventListener('input', (event) => {
+  const handleForceIntensityInput = (event) => {
+    if (updateForceProfileLockState()) {
+      event.target.value = String(forceCurveIntensity);
+      notifyForceProfileLock();
+      return;
+    }
     setForceCurveIntensity(event.target.value);
-  });
+  };
+  elements.forceCurveIntensity.addEventListener('input', handleForceIntensityInput);
+  elements.forceCurveIntensity.addEventListener('change', handleForceIntensityInput);
 }
 
 if (elements.eccentricToggle) {
-  elements.eccentricToggle.addEventListener('click', () => {
+  elements.eccentricToggle.addEventListener('click', (event) => {
+    if (updateForceProfileLockState()) {
+      event.preventDefault();
+      notifyForceProfileLock();
+      return;
+    }
+
     eccentricOverrideEnabled = !eccentricOverrideEnabled;
     elements.eccentricToggle.textContent = eccentricOverrideEnabled
       ? 'Disable eccentric profile'
@@ -374,7 +687,14 @@ if (elements.eccentricToggle) {
 }
 
 if (elements.eccentricSelect) {
-  elements.eccentricSelect.addEventListener('change', () => {
+  elements.eccentricSelect.addEventListener('change', (event) => {
+    if (updateForceProfileLockState()) {
+      event.target.value = lastEccentricMode;
+      notifyForceProfileLock();
+      return;
+    }
+
+    lastEccentricMode = elements.eccentricSelect.value;
     updateForceCurveDescriptions();
     updateForceCurveLabel();
     redrawForceCurves();
@@ -382,25 +702,6 @@ if (elements.eccentricSelect) {
   });
 }
 
-elements.engageSlider.addEventListener('input', updateEngageDisplay);
-if (elements.setCableButton) {
-  elements.setCableButton.addEventListener('click', () => {
-    if (!elements.engageSlider) return;
-    if (!motors.length) return;
-    const totalDistance = motors.reduce(
-      (sum, motor) => sum + Number(motor.simSlider.value || 0),
-      0
-    );
-    const average = totalDistance / motors.length;
-    const quantized = Math.round(Math.max(0, Math.min(MAX_TRAVEL_INCHES, average)) * 2) / 2;
-    elements.engageSlider.value = String(quantized);
-    updateEngageDisplay();
-    if (elements.message) {
-      elements.message.textContent = `Engagement distance set to ${quantized.toFixed(1)} in based on cable position.`;
-    }
-  });
-}
-updateEngageDisplay();
 updateSetToggleAppearance();
 updateWorkoutToggleAppearance();
 
@@ -421,7 +722,7 @@ function startSet() {
     const travel = motor.normalized * MAX_TRAVEL_INCHES;
     resetMotorTracking(motor, travel);
   });
-  elements.message.textContent = `Set ${currentSet} active. Cable movement will arm the servos.`;
+  setStatusMessage(`Set ${currentSet} active. Cable movement will arm the servos.`);
   updateStatuses();
   updateSetToggleAppearance();
 }
@@ -448,7 +749,7 @@ elements.reset.addEventListener('click', () => {
   workoutLog.length = 0;
   elements.logList.innerHTML = '';
   updateStatuses();
-  elements.message.textContent = 'Workout reset. Adjust engagement or force curve when ready.';
+  setStatusMessage('Workout reset. Adjust engagement or force curve when ready.');
   if (elements.workoutState) {
     elements.workoutState.textContent = workoutActive ? 'Workout Started' : 'Workout Not Started';
   }
@@ -468,17 +769,21 @@ function stopSet(options = {}) {
     if (elements.workoutState) {
       elements.workoutState.textContent = partial ? 'Set Logged' : 'Set Complete';
     }
-    elements.message.textContent = partial
-      ? `Set ${currentSet} logged with ${currentRep} reps.`
-      : `Set ${currentSet} complete. Press “Start Set” when you are ready for the next round.`;
+    setStatusMessage(
+      partial
+        ? `Set ${currentSet} logged with ${currentRep} reps.`
+        : `Set ${currentSet} complete. Press “Start Set” when you are ready for the next round.`
+    );
     recorded = true;
   } else {
     if (elements.workoutState) {
       elements.workoutState.textContent = workoutActive ? 'Workout Started' : 'Workout Not Started';
     }
-    elements.message.textContent = currentRep >= totalReps
-      ? 'Set complete. Press “Start Set” for the next round.'
-      : 'Set paused. Press “Start Set” to resume.';
+    setStatusMessage(
+      currentRep >= totalReps
+        ? 'Set complete. Press “Start Set” for the next round.'
+        : 'Set paused. Press “Start Set” to resume.'
+    );
   }
 
   motors.forEach((motor) => {
@@ -504,17 +809,98 @@ motors.forEach((motor) => {
   motor.simSlider.addEventListener('input', () => {
     const sliderDistance = Number(motor.simSlider.value);
     const normalized = Math.max(0, Math.min(1, sliderDistance / MAX_TRAVEL_INCHES));
+    const previous = motor.normalized;
+    const previousDistance = previous * MAX_TRAVEL_INCHES;
+    if (sliderDistance > previousDistance + SIM_SLIDER_STEP / 2) {
+      motor.direction = 1;
+      motor.forceDirection = 1;
+    } else if (sliderDistance < previousDistance - SIM_SLIDER_STEP / 2) {
+      motor.direction = -1;
+      motor.forceDirection = -1;
+    }
     motor.normalized = normalized;
     motor.trail.push(normalized);
     if (motor.trail.length > TRAIL_LENGTH) {
       motor.trail.shift();
     }
     motor.cableLabel.textContent = (normalized * MAX_TRAVEL_INCHES).toFixed(1);
+    motor.lastForceTravel = sliderDistance;
     drawWave(motor);
     refreshMotorResistance(motor);
+    updateForceProfileLockState();
   });
+  motor.simSlider.addEventListener('change', () => {
+    const distance = Number(motor.simSlider.value || 0);
+    if (motor.setArmed) {
+      const start = motor.armedTravelStart ?? DEFAULT_RETRACTION_BOTTOM;
+      const required = start + 1;
+      const tolerance = SIM_SLIDER_STEP / 2;
+      if (distance < required - tolerance) {
+        const label = formatMotorLabel(motor.id);
+        setStatusMessage(
+          `${label} cable must be pulled at least 1.0 in before locking the length.`,
+          { tone: 'error' }
+        );
+        return;
+      }
+      setMotorEngagementDistance(motor, distance, { source: 'set-button' });
+      disarmMotorCableSet(motor, { silent: true });
+    }
+    updateForceProfileLockState();
+  });
+  if (motor.engagementSlider) {
+    motor.engagementSlider.addEventListener('input', () => {
+      if (!motor.setArmed) {
+        motor.engagementSlider.value = motor.engagementDistance.toFixed(1);
+        renderMotorEngagement(motor);
+        return;
+      }
+      const distance = Number(motor.engagementSlider.value || 0);
+      renderMotorEngagement(motor, { preview: distance });
+    });
+    motor.engagementSlider.addEventListener('change', () => {
+      const distance = Number(motor.engagementSlider.value || 0);
+      if (!motor.setArmed) {
+        const label = formatMotorLabel(motor.id);
+        setStatusMessage(
+          `${label} cable length must be armed before adjusting the engagement slider.`,
+          { tone: 'error' }
+        );
+        motor.engagementSlider.value = motor.engagementDistance.toFixed(1);
+        renderMotorEngagement(motor);
+        return;
+      }
+      const start = motor.armedTravelStart ?? DEFAULT_RETRACTION_BOTTOM;
+      const required = start + 1;
+      const tolerance = SIM_SLIDER_STEP / 2;
+      if (distance < required - tolerance) {
+        const label = formatMotorLabel(motor.id);
+        setStatusMessage(
+          `${label} cable must be pulled at least 1.0 in before locking the length.`,
+          { tone: 'error' }
+        );
+        motor.engagementSlider.value = motor.engagementDistance.toFixed(1);
+        renderMotorEngagement(motor);
+        return;
+      }
+      setMotorEngagementDistance(motor, distance, { source: 'engagement' });
+      disarmMotorCableSet(motor, { silent: true });
+      updateForceProfileLockState();
+    });
+  }
   motor.baseLabel.textContent = `${motor.baseResistance} lb`;
   refreshMotorResistance(motor);
+
+  if (motor.setCableButton) {
+    motor.setCableButton.addEventListener('click', () => {
+      toggleMotorCableSet(motor);
+    });
+  }
+  if (motor.retractCableButton) {
+    motor.retractCableButton.addEventListener('click', () => {
+      startMotorRetraction(motor);
+    });
+  }
 });
 
 function updateMotorToggle() {
@@ -549,14 +935,21 @@ function applyPowerState() {
     elements.reset,
     elements.forceSelect,
     elements.forceCurveIntensity,
-    elements.engageSlider,
-    elements.setCableButton,
     elements.motorToggle,
   ];
 
   motors.forEach((motor) => {
+    if (motor.setCableButton) {
+      interactive.push(motor.setCableButton);
+    }
+    if (motor.retractCableButton) {
+      interactive.push(motor.retractCableButton);
+    }
     motor.slider.disabled = !powerOn;
     motor.simSlider.disabled = !powerOn;
+    if (motor.engagementSlider) {
+      motor.engagementSlider.disabled = !powerOn;
+    }
   });
 
   interactive.forEach((el) => {
@@ -579,6 +972,13 @@ function applyPowerState() {
   }
 
   if (!powerOn) {
+    motors.forEach((motor) => {
+      disarmMotorCableSet(motor, { silent: true });
+      if (motor.retractionActive) {
+        motor.retractionActive = false;
+        markRetractActive(motor, false);
+      }
+    });
     stopSet();
     workoutActive = false;
     updateWorkoutToggleAppearance();
@@ -586,7 +986,7 @@ function applyPowerState() {
       elements.workoutState.textContent = 'System Offline';
       elements.workoutState.classList.remove('active');
     }
-    elements.message.textContent = 'Power system on to resume control.';
+    setStatusMessage('Power system on to resume control.');
     motorsRunning = false;
     updateMotorToggle();
   } else {
@@ -668,12 +1068,18 @@ function getForceCurveMultiplier(mode, normalized, direction) {
   }
 }
 
-function computeForceMultiplier(mode, normalized, derivative) {
-  const direction = derivative < 0 ? -1 : 1;
-  let activeMode = mode;
-  if (direction < 0 && eccentricOverrideEnabled && elements.eccentricSelect) {
-    activeMode = elements.eccentricSelect.value;
+function getActiveEccentricMode(fallbackMode) {
+  if (!elements.eccentricSelect) {
+    return fallbackMode;
   }
+  return eccentricOverrideEnabled ? elements.eccentricSelect.value : fallbackMode;
+}
+
+function computeForceMultiplier(mode, normalized, directionHint) {
+  const direction = directionHint < 0 ? -1 : 1;
+  const descending = direction < 0;
+  const eccentricMode = getActiveEccentricMode(mode);
+  const activeMode = descending ? eccentricMode : mode;
   return getForceCurveMultiplier(activeMode, normalized, direction);
 }
 
@@ -790,10 +1196,7 @@ function redrawForceCurves() {
   const mode = elements.forceSelect.value;
   drawForceProfile(elements.forceCurveConcentric, mode, 1);
 
-  const eccentricMode =
-    eccentricOverrideEnabled && elements.eccentricSelect
-      ? elements.eccentricSelect.value
-      : mode;
+  const eccentricMode = getActiveEccentricMode(mode);
   drawForceProfile(elements.forceCurveEccentric, eccentricMode, -1);
 }
 
@@ -801,15 +1204,19 @@ function updateForceCurveDescriptions() {
   const concentricMode = elements.forceSelect.value;
   const intensity = forceCurveIntensity;
   if (elements.forceDescription) {
-    elements.forceDescription.textContent = `Concentric: ${getForceCurveCopy(concentricMode, intensity)}`;
+    elements.forceDescription.textContent = `Force curve: ${getForceCurveCopy(
+      concentricMode,
+      intensity
+    )}`;
   }
 
   if (elements.eccentricDescription) {
-    const eccMode =
-      elements.eccentricSelect && eccentricOverrideEnabled
-        ? elements.eccentricSelect.value
-        : concentricMode;
-    elements.eccentricDescription.textContent = `Eccentric: ${getForceCurveCopy(eccMode, intensity)}`;
+    const eccMode = getActiveEccentricMode(concentricMode);
+    const prefix = eccentricOverrideEnabled ? 'Eccentric override' : 'Eccentric';
+    elements.eccentricDescription.textContent = `${prefix}: ${getForceCurveCopy(
+      eccMode,
+      intensity
+    )}`;
   }
 }
 
@@ -820,7 +1227,7 @@ function updateForceCurveLabel() {
 
   if (eccentricOverrideEnabled && elements.eccentricSelect) {
     const eccentricLabel = elements.eccentricSelect.options[elements.eccentricSelect.selectedIndex].text;
-    elements.forceLabel.textContent = `${concentricLabel} / ${eccentricLabel} (eccentric)`;
+    elements.forceLabel.textContent = `${concentricLabel} / ${eccentricLabel}`;
   } else {
     elements.forceLabel.textContent = concentricLabel;
   }
@@ -885,14 +1292,15 @@ function drawWave(motor) {
   const topPadding = 20;
   const bottomPadding = 24;
   const usableHeight = height - topPadding - bottomPadding;
+  const circleRadius = 16;
   const circleX = width - 46;
-  const availableWidth = circleX - 16;
+  const availableWidth = circleX - circleRadius;
   const headY = topPadding + (1 - motor.normalized) * usableHeight;
 
-  ctx.lineWidth = 4;
+  ctx.lineWidth = 8;
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
-  const gradient = ctx.createLinearGradient(0, 0, circleX, 0);
+  const gradient = ctx.createLinearGradient(0, 0, circleX - circleRadius, 0);
   gradient.addColorStop(0, 'rgba(31, 139, 255, 0)');
   gradient.addColorStop(0.18, 'rgba(31, 139, 255, 0.45)');
   gradient.addColorStop(1, 'rgba(127, 255, 212, 0.95)');
@@ -915,17 +1323,18 @@ function drawWave(motor) {
   } else {
     ctx.moveTo(0, headY);
   }
-  ctx.lineTo(circleX, headY);
+  ctx.lineTo(circleX - circleRadius, headY);
   ctx.stroke();
 
   ctx.fillStyle = 'rgba(31, 139, 255, 0.35)';
   ctx.beginPath();
-  ctx.arc(circleX, headY, 16, 0, TWO_PI);
+  ctx.arc(circleX, headY, circleRadius, 0, TWO_PI);
   ctx.fill();
   ctx.lineWidth = 2;
   ctx.strokeStyle = 'rgba(127, 255, 212, 0.85)';
   ctx.stroke();
 }
+
 
 function update(timestamp) {
   const delta = (timestamp - lastTimestamp) / 1000;
@@ -940,31 +1349,73 @@ function update(timestamp) {
       drawGauge(motor);
       drawWave(motor);
     });
+    updateForceProfileLockState();
     requestAnimationFrame(update);
     return;
   }
 
-  const engageDistance = elements.engageSlider
-    ? Math.max(0, Math.min(MAX_TRAVEL_INCHES, Number(elements.engageSlider.value)))
-    : 0;
-  const engageThreshold = Math.min(0.98, engageDistance / MAX_TRAVEL_INCHES);
   const mode = elements.forceSelect ? elements.forceSelect.value : 'linear';
 
   motors.forEach((motor) => {
+    if (motor.retractionActive) {
+      const tolerance = SIM_SLIDER_STEP / 2;
+      const currentValue = Number(motor.simSlider.value);
+      if (currentValue > motor.retractionTarget + tolerance) {
+        const next = Math.max(
+          motor.retractionTarget,
+          currentValue - motor.retractionSpeed * delta
+        );
+        const quantized = quantize(next, SIM_SLIDER_STEP);
+        motor.simSlider.value = quantized.toFixed(1);
+      } else if (currentValue > motor.retractionTarget) {
+        const quantized = quantize(motor.retractionTarget, SIM_SLIDER_STEP);
+        motor.simSlider.value = quantized.toFixed(1);
+      } else {
+        motor.retractionActive = false;
+        markRetractActive(motor, false);
+        setMotorEngagementDistance(motor, motor.retractionTarget, {
+          skipSimSync: true,
+          source: 'retraction',
+          announce: true,
+        });
+      }
+    }
+
     const sliderDistance = Number(motor.simSlider.value);
     const normalized = Math.max(0, Math.min(1, sliderDistance / MAX_TRAVEL_INCHES));
     const previous = motor.normalized;
     motor.normalized = normalized;
     const travel = motor.normalized * MAX_TRAVEL_INCHES;
-    const derivative = delta > 0 ? (normalized - previous) / delta : 0;
-    motor.direction = derivative >= 0 ? 1 : -1;
-
-    if (motorsRunning && setActive && !motor.engaged && motor.normalized >= engageThreshold) {
-      motor.engaged = true;
-      if (motor.id === 'left') {
-        elements.message.textContent = `Left motor engaged at ${elements.engageSlider.value} in. Rep tracking armed.`;
-      }
+    const forceDelta = travel - motor.lastForceTravel;
+    if (Math.abs(forceDelta) > MOVEMENT_EPSILON) {
+      motor.forceDirection = forceDelta > 0 ? 1 : -1;
+      motor.lastForceTravel = travel;
     }
+
+    const engageDistance = motor.engagementDistance;
+    const engageThresholdDistance = Math.min(
+      MAX_TRAVEL_INCHES,
+      engageDistance + WEIGHT_ENGAGE_OFFSET
+    );
+    const engageThreshold = Math.min(
+      0.98,
+      engageThresholdDistance / MAX_TRAVEL_INCHES
+    );
+
+    if (
+      motorsRunning &&
+      setActive &&
+      !motor.engaged &&
+      motor.normalized >= engageThreshold
+    ) {
+      motor.engaged = true;
+      const label = formatMotorLabel(motor.id);
+      setStatusMessage(
+        `${label} motor engaged at ${engageThresholdDistance.toFixed(1)} in. Rep tracking armed.`
+      );
+    }
+
+    const resistance = resolveMotorResistance(motor, engageDistance, mode);
 
     if (!setActive) {
       motor.engaged = false;
@@ -975,7 +1426,7 @@ function update(timestamp) {
       resetMotorTracking(motor, travel);
     }
 
-    motor.currentResistance = resolveMotorResistance(motor, engageDistance, mode);
+    motor.currentResistance = resistance;
 
     motor.cableLabel.textContent = travel.toFixed(1);
 
@@ -989,6 +1440,7 @@ function update(timestamp) {
       motor.lastTravel = travel;
       if (Math.abs(deltaTravel) > MOVEMENT_EPSILON) {
         motor.direction = deltaTravel > 0 ? 1 : -1;
+        motor.forceDirection = motor.direction;
       }
 
       if (motor.direction >= 0) {
@@ -1023,6 +1475,8 @@ function update(timestamp) {
     drawWave(motor);
   });
 
+  updateForceProfileLockState();
+
   requestAnimationFrame(update);
 }
 
@@ -1037,7 +1491,7 @@ function finishSet() {
   if (elements.workoutState) {
     elements.workoutState.textContent = 'Set Complete';
   }
-  elements.message.textContent = `Set ${currentSet} complete. Press “Start Set” when you are ready for the next round.`;
+  setStatusMessage(`Set ${currentSet} complete. Press “Start Set” when you are ready for the next round.`);
   recordWorkoutSet();
   updateStatuses();
 }
@@ -1056,7 +1510,7 @@ function synchronizeRepProgress() {
     return;
   }
 
-  elements.message.textContent = `Set ${currentSet}: rep ${currentRep} complete.`;
+  setStatusMessage(`Set ${currentSet}: rep ${currentRep} complete.`);
   updateStatuses();
 }
 
@@ -1082,6 +1536,10 @@ function recordWorkoutSet(partial = false) {
   elements.logList.prepend(item);
 }
 
+motors.forEach((motor) => {
+  setMotorEngagementDistance(motor, DEFAULT_RETRACTION_BOTTOM, { announce: false });
+});
+
 requestAnimationFrame(update);
 
 updateStatuses();
@@ -1093,6 +1551,8 @@ if (elements.eccentricPanel) {
   elements.eccentricPanel.hidden = true;
 }
 applyPowerState();
+
+updateForceProfileLockState();
 
 requestAnimationFrame(() => {
   syncWaveCanvasSizes();

--- a/dragon_gym/index.html
+++ b/dragon_gym/index.html
@@ -77,20 +77,9 @@
         </div>
         <p class="status-message" id="workoutMessage">Tap “Start Workout” to arm the set controls.</p>
       </article>
-      <article class="engagement-card" aria-label="Cable engagement distance">
-        <h3>Cable Engagement</h3>
-        <label for="engageDistance" class="slider-field">
-          <span>Engagement distance</span>
-          <input type="range" id="engageDistance" min="0" max="24" step="0.5" value="1.5" />
-        </label>
-        <p class="hint">Engage after <span id="engageDisplay">1.5</span> in of travel.</p>
-        <div class="engagement-actions">
-          <button type="button" class="ghost" id="setCableLength">Set Cable Length</button>
-        </div>
-      </article>
       <article class="motor-card" data-motor="left">
         <div class="gauge-wrapper">
-          <canvas class="resistance-gauge" id="leftGauge" width="320" height="320" aria-hidden="true"></canvas>
+          <canvas class="resistance-gauge" id="leftGauge" width="540" height="540" aria-hidden="true"></canvas>
           <div class="gauge-center">
             <span class="motor-name">Left</span>
             <span class="current-resistance" id="leftCurrentResistance">0 lb</span>
@@ -106,15 +95,41 @@
             <dd id="leftRepCount">0</dd>
           </div>
         </dl>
-        <label class="slider-field">
-          <span>Adjust resistance</span>
-          <input type="range" id="leftResistance" min="0" max="300" value="120" />
-        </label>
+        <div class="resistance-control">
+          <label class="slider-field">
+            <span>Adjust resistance</span>
+            <input type="range" id="leftResistance" min="0" max="300" value="120" />
+          </label>
+        </div>
+        <div class="motor-engagement" aria-label="Left motor cable engagement">
+          <div class="engagement-control">
+            <label class="slider-field">
+              <span>Set engagement distance</span>
+              <input
+                type="range"
+                id="leftEngagementSlider"
+                min="1"
+                max="24"
+                step="0.1"
+                value="1"
+              />
+            </label>
+          </div>
+          <div class="engagement-readout" aria-live="polite">
+            <span class="label">Current engagement distance</span>
+            <span class="value" id="leftEngageDisplay">1.0 in</span>
+          </div>
+          <p class="hint">Weight engages at <span id="leftEngageThreshold">2.0 in</span>.</p>
+          <div class="engagement-actions">
+            <button type="button" class="ghost" id="leftSetCableLength">Set Cable Length</button>
+            <button type="button" class="ghost" id="leftRetractCable">Retract Cable</button>
+          </div>
+        </div>
       </article>
 
       <article class="motor-card" data-motor="right">
         <div class="gauge-wrapper">
-          <canvas class="resistance-gauge" id="rightGauge" width="320" height="320" aria-hidden="true"></canvas>
+          <canvas class="resistance-gauge" id="rightGauge" width="540" height="540" aria-hidden="true"></canvas>
           <div class="gauge-center">
             <span class="motor-name">Right</span>
             <span class="current-resistance" id="rightCurrentResistance">0 lb</span>
@@ -130,10 +145,36 @@
             <dd id="rightRepCount">0</dd>
           </div>
         </dl>
-        <label class="slider-field">
-          <span>Adjust resistance</span>
-          <input type="range" id="rightResistance" min="0" max="300" value="120" />
-        </label>
+        <div class="resistance-control">
+          <label class="slider-field">
+            <span>Adjust resistance</span>
+            <input type="range" id="rightResistance" min="0" max="300" value="120" />
+          </label>
+        </div>
+        <div class="motor-engagement" aria-label="Right motor cable engagement">
+          <div class="engagement-control">
+            <label class="slider-field">
+              <span>Set engagement distance</span>
+              <input
+                type="range"
+                id="rightEngagementSlider"
+                min="1"
+                max="24"
+                step="0.1"
+                value="1"
+              />
+            </label>
+          </div>
+          <div class="engagement-readout" aria-live="polite">
+            <span class="label">Current engagement distance</span>
+            <span class="value" id="rightEngageDisplay">1.0 in</span>
+          </div>
+          <p class="hint">Weight engages at <span id="rightEngageThreshold">2.0 in</span>.</p>
+          <div class="engagement-actions">
+            <button type="button" class="ghost" id="rightSetCableLength">Set Cable Length</button>
+            <button type="button" class="ghost" id="rightRetractCable">Retract Cable</button>
+          </div>
+        </div>
       </article>
     </section>
 
@@ -160,31 +201,46 @@
           <div class="sim-slider-group">
             <label class="sim-slider">
               <span>Left cable length</span>
-              <input type="range" id="leftSim" min="0" max="24" step="0.1" value="0" />
+              <input type="range" id="leftSim" min="1" max="24" step="0.1" value="1" />
             </label>
             <label class="sim-slider">
               <span>Right cable length</span>
-              <input type="range" id="rightSim" min="0" max="24" step="0.1" value="0" />
+              <input type="range" id="rightSim" min="1" max="24" step="0.1" value="1" />
             </label>
           </div>
         </section>
       </section>
       <section class="force-panel" aria-label="Force curve profiles" id="forceCurvePanel" hidden>
         <h3>Force Curve Profiles</h3>
+        <p class="hint lock-hint" id="forceCurveLockHint" hidden aria-live="polite">
+          Retract both cables to or below their engagement distance to adjust these settings.
+        </p>
         <div class="force-curve-group">
-          <label>
-            <span>Force curve mode (concentric)</span>
-            <select id="forceCurve">
-              <option value="linear">Linear</option>
-              <option value="chain">Chain mode</option>
-              <option value="band">Band mode</option>
-              <option value="reverse-chain">Reverse chain</option>
-            </select>
-          </label>
-          <label>
-            <span>Force curve intensity (%)</span>
-            <input type="number" id="forceCurveIntensity" min="0" max="100" step="1" value="20" />
-          </label>
+          <div class="force-curve-header">
+            <div class="force-curve-inputs">
+              <label>
+                <span>Force curve mode</span>
+                <select id="forceCurve">
+                  <option value="linear">Linear</option>
+                  <option value="chain">Chain mode</option>
+                  <option value="band">Band mode</option>
+                  <option value="reverse-chain">Reverse chain</option>
+                </select>
+              </label>
+              <label>
+                <span>Force curve intensity (%)</span>
+                <input type="number" id="forceCurveIntensity" min="0" max="100" step="1" value="20" />
+              </label>
+            </div>
+            <button
+              class="ghost eccentric-toggle"
+              id="eccentricToggle"
+              type="button"
+              aria-expanded="false"
+            >
+              Enable eccentric profile
+            </button>
+          </div>
           <canvas
             class="force-curve-graph"
             id="forceCurveConcentric"
@@ -192,15 +248,7 @@
             height="220"
             aria-hidden="true"
           ></canvas>
-          <p class="hint" id="forceCurveDescription">Concentric: Equal load through the pull and return.</p>
-          <button
-            class="ghost eccentric-toggle"
-            id="eccentricToggle"
-            type="button"
-            aria-expanded="false"
-          >
-            Enable eccentric profile
-          </button>
+          <p class="hint" id="forceCurveDescription">Force curve: Equal load through the pull and return.</p>
           <div class="eccentric-panel" id="eccentricPanel" hidden>
             <label>
               <span>Eccentric force curve</span>

--- a/dragon_gym/page-template.html
+++ b/dragon_gym/page-template.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dragon Gym — Page Template</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="app-shell template-shell">
+    <div class="hud-corner top-left" aria-label="Template navigation">
+      <button class="ghost template-nav" type="button">Back to Dashboard</button>
+    </div>
+    <div class="hud-corner top-right" aria-label="Template status">
+      <div class="template-status-pill" role="status">
+        <span class="label">State</span>
+        <span class="value">Draft</span>
+      </div>
+    </div>
+
+    <section class="system-card template-hero" aria-label="Page overview">
+      <div class="logo-block">
+        <img src="assets/dragonai-logo.svg" alt="DragonAI neon dragon" class="logo-image" />
+        <div class="branding-copy">
+          <p class="eyebrow">Dragon Gym Interface</p>
+          <h1>Template Page Title</h1>
+        </div>
+      </div>
+      <div class="template-hero-actions">
+        <button class="primary" type="button">Primary Action</button>
+        <button class="ghost" type="button">Secondary Action</button>
+      </div>
+    </section>
+
+    <section class="template-content" aria-label="Content sections">
+      <article class="template-card">
+        <header>
+          <h2>Section Heading</h2>
+          <p>Short description for this section. Replace this copy with your page content.</p>
+        </header>
+        <div class="template-card-body">
+          <p>
+            This template mirrors the Dragon Gym aesthetic with elevated cards, neon accents, and flexible layout.
+            Use this space to showcase data, instructions, or dashboards for additional tabs.
+          </p>
+        </div>
+      </article>
+
+      <article class="template-card">
+        <header>
+          <h2>Secondary Section</h2>
+          <p>Highlight complementary information or controls here.</p>
+        </header>
+        <div class="template-card-body">
+          <ul>
+            <li>Use cards to group related stats.</li>
+            <li>Swap headings and copy to match your feature.</li>
+            <li>Duplicate this layout to build more panels.</li>
+          </ul>
+        </div>
+      </article>
+
+      <article class="template-card template-card--accent">
+        <header>
+          <h2>Callout Panel</h2>
+          <p>Draw attention to alerts, summaries, or quick tips.</p>
+        </header>
+        <div class="template-card-body">
+          <p>
+            Combine accent colors with concise messaging for quick-glance insights.
+            Buttons can be placed here to drive users toward critical actions.
+          </p>
+          <div class="template-actions">
+            <button class="accent" type="button">Call to Action</button>
+            <button class="ghost" type="button">Learn More</button>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/dragon_gym/styles.css
+++ b/dragon_gym/styles.css
@@ -66,7 +66,7 @@ body {
   width: min(100%, 1080px);
   min-height: 1920px;
   margin: 0 auto;
-  padding: clamp(150px, 18vw, 220px) clamp(20px, 4vw, 32px) 60px;
+  padding: clamp(75px, 9vw, 110px) clamp(20px, 4vw, 32px) 60px;
   display: flex;
   flex-direction: column;
   gap: 28px;
@@ -261,13 +261,22 @@ body {
 
 .resistance-overview {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 24px;
-  align-items: start;
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+  align-items: stretch;
+}
+
+
+.resistance-overview > * {
+  width: 100%;
+  justify-self: stretch;
 }
 
 .status-card {
   grid-column: 1 / -1;
+}
+
+.status-card {
   background: linear-gradient(150deg, rgba(8, 14, 25, 0.94), rgba(4, 7, 15, 0.9));
   border-radius: var(--card-radius);
   border: 1px solid var(--border);
@@ -318,12 +327,120 @@ body {
 .engagement-actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 }
 
 .engagement-actions button {
-  flex: 0 1 200px;
+  flex: 0 1 220px;
   justify-content: center;
+}
+
+
+.resistance-control,
+.motor-engagement .engagement-control {
+  margin: 32px auto 0;
+  width: min(100%, 760px);
+  display: flex;
+  justify-content: center;
+  justify-self: center;
+}
+
+.slider-field {
+  display: grid;
+  gap: 20px;
+  background: linear-gradient(160deg, rgba(10, 16, 28, 0.94), rgba(6, 11, 20, 0.9));
+  border-radius: 999px;
+  border: 1px solid rgba(62, 90, 118, 0.55);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.4);
+  padding: 34px 48px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 1.15rem;
+  text-align: center;
+  justify-items: center;
+  align-items: center;
+  width: min(100%, 640px);
+  margin: 0 auto;
+}
+
+.slider-field span {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.15rem;
+}
+
+.slider-field input[type="range"] {
+  width: 100%;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.motor-engagement {
+  margin: 28px auto 0;
+  width: min(100%, 760px);
+  display: grid;
+  gap: 18px;
+  text-align: center;
+  justify-items: center;
+  justify-self: center;
+}
+
+.motor-engagement .engagement-readout {
+  background: rgba(10, 16, 28, 0.72);
+  border-radius: 18px;
+  border: 1px solid rgba(62, 90, 118, 0.4);
+  padding: 20px 28px;
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.motor-engagement .hint {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.motor-engagement .engagement-readout .label {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.motor-engagement .engagement-readout .value {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.45rem;
+  letter-spacing: 0.1em;
+  color: #7fffd4;
+}
+
+.motor-engagement .hint {
+  font-size: 0.88rem;
+}
+
+.motor-engagement .engagement-actions {
+  justify-content: center;
+}
+
+button.is-pulsing {
+  animation: pulse-blue 1.2s ease-in-out infinite;
+  box-shadow: 0 0 0 0 rgba(64, 160, 255, 0.45);
+  border-color: rgba(64, 160, 255, 0.75) !important;
+}
+
+@keyframes pulse-blue {
+  0% {
+    box-shadow: 0 0 0 0 rgba(64, 160, 255, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 16px rgba(64, 160, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(64, 160, 255, 0);
+  }
 }
 
 .status-header {
@@ -355,6 +472,10 @@ body {
   gap: 22px;
   position: relative;
   overflow: hidden;
+  justify-items: center;
+  width: 100%;
+  min-height: 100%;
+  align-content: start;
 }
 
 .motor-card::before {
@@ -373,7 +494,7 @@ body {
 
 .gauge-wrapper {
   position: relative;
-  width: min(100%, 320px);
+  width: min(100%, clamp(320px, 45vw, 480px));
   aspect-ratio: 1 / 1;
   justify-self: center;
 }
@@ -388,8 +509,8 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 62%;
-  height: 62%;
+  width: min(68%, 360px);
+  height: min(68%, 360px);
   transform: translate(-50%, -50%);
   border-radius: 50%;
   display: grid;
@@ -405,12 +526,12 @@ body {
   font-family: "Rajdhani", sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  font-size: 1rem;
+  font-size: clamp(1rem, 2.1vw, 1.35rem);
   color: var(--text-muted);
 }
 
 .current-resistance {
-  font-size: clamp(1.6rem, 2.4vw, 2.3rem);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
   font-weight: 600;
 }
 
@@ -419,6 +540,12 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
+  justify-self: stretch;
+}
+
+.motor-meta dt,
+.motor-meta dd {
+  text-align: left;
 }
 
 .motor-meta dt {
@@ -463,10 +590,29 @@ body {
   gap: 12px;
 }
 
+
 .force-curve-group {
   display: grid;
   gap: 16px;
   max-width: 620px;
+  justify-items: stretch;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.force-curve-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+}
+
+.force-curve-inputs {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  flex: 1 1 auto;
 }
 
 .force-curve-group label {
@@ -476,6 +622,14 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-family: "Rajdhani", sans-serif;
+  justify-items: center;
+  width: min(100%, 420px);
+}
+
+.force-curve-inputs label {
+  justify-items: stretch;
+  text-align: left;
+  width: 100%;
 }
 
 .force-curve-group select,
@@ -491,6 +645,7 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   transition: border-color var(--transition), box-shadow var(--transition);
+  text-align: center;
 }
 
 .force-curve-group select:focus,
@@ -511,11 +666,27 @@ body {
 }
 
 .eccentric-toggle {
-  justify-self: start;
+  justify-self: center;
   padding: 8px 16px;
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.force-curve-header .eccentric-toggle {
+  align-self: center;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .force-curve-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .force-curve-header .eccentric-toggle {
+    width: 100%;
+  }
 }
 
 .eccentric-panel {
@@ -526,6 +697,8 @@ body {
   border: 1px solid var(--border);
   background: rgba(6, 12, 22, 0.85);
   box-shadow: inset 0 0 0 1px rgba(31, 139, 255, 0.08);
+  justify-items: center;
+  text-align: center;
 }
 
 .eccentric-panel[hidden] {
@@ -681,6 +854,11 @@ body {
   color: var(--text-muted);
 }
 
+.status-message.is-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
 .visual-panel {
   background: linear-gradient(160deg, rgba(9, 16, 27, 0.92), rgba(4, 7, 15, 0.9));
   border-radius: var(--card-radius);
@@ -755,6 +933,36 @@ body {
   gap: 14px;
 }
 
+.force-panel {
+  justify-items: center;
+  text-align: center;
+}
+
+.force-panel.is-locked .force-curve-group {
+  opacity: 0.55;
+  filter: saturate(0.7);
+  transition: opacity var(--transition), filter var(--transition);
+}
+
+.force-panel.is-locked .force-curve-group select,
+.force-panel.is-locked .force-curve-group input,
+.force-panel.is-locked .force-curve-group button {
+  cursor: not-allowed;
+}
+
+.force-panel .lock-hint {
+  margin: 0;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 79, 109, 0.32);
+  background: rgba(255, 79, 109, 0.12);
+  color: var(--danger);
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-family: "Rajdhani", sans-serif;
+}
+
 .force-panel h3,
 .log-panel h3,
 .selector-panel h3 {
@@ -763,6 +971,14 @@ body {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.force-panel h3 {
+  justify-self: center;
+}
+
+.force-panel .hint {
+  text-align: center;
 }
 
 .log-list {
@@ -910,6 +1126,14 @@ body {
   .hud-corner.top-right {
     justify-content: flex-end;
   }
+
+  .resistance-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .status-card {
+    grid-column: auto;
+  }
 }
 
 @media (max-width: 768px) {
@@ -925,5 +1149,138 @@ body {
 
   .status-stack {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+
+/* Template page layout */
+.template-shell {
+  min-height: auto;
+  gap: clamp(32px, 6vw, 48px);
+}
+
+.template-nav {
+  min-width: 0;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(62, 90, 118, 0.45);
+  background: rgba(8, 16, 28, 0.72);
+  color: var(--text-muted);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.template-status-pill {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 12px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(62, 90, 118, 0.4);
+  background: rgba(8, 16, 28, 0.7);
+  box-shadow: 0 0 22px rgba(31, 139, 255, 0.18);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.68rem;
+  gap: 4px;
+}
+
+.template-status-pill .value {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.15rem;
+  letter-spacing: 0.3em;
+  color: var(--accent-secondary);
+}
+
+.template-hero {
+  gap: clamp(16px, 3vw, 32px);
+}
+
+.template-hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.template-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.template-card {
+  background: linear-gradient(135deg, rgba(10, 17, 31, 0.92), rgba(4, 9, 19, 0.92));
+  border-radius: var(--card-radius);
+  border: 1px solid var(--border);
+  padding: clamp(20px, 2.5vw, 28px);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.template-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.template-card header h2 {
+  margin: 0;
+  font-family: "Rajdhani", sans-serif;
+  font-size: 1.5rem;
+  letter-spacing: 0.12em;
+}
+
+.template-card header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.template-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: rgba(223, 230, 255, 0.92);
+  line-height: 1.6;
+}
+
+.template-card ul {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+}
+
+.template-card--accent {
+  border-color: rgba(31, 139, 255, 0.5);
+  box-shadow: 0 24px 55px rgba(31, 139, 255, 0.28);
+}
+
+.template-card--accent h2 {
+  color: var(--accent);
+}
+
+.template-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 720px) {
+  .template-hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .template-hero-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .template-status-pill {
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add engagement distance sliders to each motor card so cable length can be set from either control
- sync the simulator logic with slider previews, lock checks, and power-state handling
- enlarge the adjust-resistance and engagement pill styling for centered, higher-visibility controls

## Testing
- node --check dragon_gym/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d74b272bf883278873cba2b6eec7c2